### PR TITLE
[bug fix] Linux上部署时，访问usermanager.js会404

### DIFF
--- a/SpinBladeArena/Pages/Index.cshtml
+++ b/SpinBladeArena/Pages/Index.cshtml
@@ -42,7 +42,7 @@
             </tr>
         </tfoot>
     </table>
-    <script src="~/usermanager.js"></script>
+    <script src="~/userManager.js"></script>
     <script>
         async function createRoom() {
             const createLobbyResp = await fetch('/lobby', {

--- a/SpinBladeArena/Pages/Lobby.cshtml
+++ b/SpinBladeArena/Pages/Lobby.cshtml
@@ -25,7 +25,7 @@
 <body>
     <canvas id="canvas">您的浏览器不支持Canvas元素</canvas>
     <script src="~/libs/signalr.js"></script>
-    <script src="~/usermanager.js" asp-append-version="true"></script>
+    <script src="~/userManager.js" asp-append-version="true"></script>
     <script src="~/game.js" asp-append-version="true"></script>
 </body>
 </html>


### PR DESCRIPTION
`usermanager.js`里的`m`要改成**大写的`M`**，不然在linux上部署会404。因为linux上文件名区分大小写